### PR TITLE
enable different print formats

### DIFF
--- a/nextcloud_integration/nextcloud_integration/doctype/nextcloud_print_list/nextcloud_print_list.json
+++ b/nextcloud_integration/nextcloud_integration/doctype/nextcloud_print_list/nextcloud_print_list.json
@@ -24,7 +24,6 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Print Format",
-   "options": "Standard",
    "reqd": 1
   }
  ],


### PR DESCRIPTION
removed an option where a preset Printformat prevents the user from changing to a printformat of choice

